### PR TITLE
Avoid warnings on Erlang/OTP 17.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,3 @@
 %% Dogfooding
+{erl_opts, [{platform_define, "^[0-9]+", namespaced_dicts}]}.
 {eunit_opts, [no_tty, {report, {eunit_progress, [colored, profile]}}]}.

--- a/src/eunit_progress.erl
+++ b/src/eunit_progress.erl
@@ -27,8 +27,14 @@
          start/1
         ]).
 
+-ifdef(namespaced_dicts).
+-type euf_dict() :: dict:dict().
+-else.
+-type euf_dict() :: dict().
+-endif.
+
 -record(state, {
-          status = dict:new() :: dict(),
+          status = dict:new() :: euf_dict(),
           failures = [] :: [[pos_integer()]],
           skips = [] :: [[pos_integer()]],
           timings = binomial_heap:new() :: binomial_heap:binomial_heap(),


### PR DESCRIPTION
The solution is taken from https://github.com/eproxus/meck.
