### PR TITLE
Support for hamcrest assertions.

### DIFF
--- a/src/eunit_progress.erl
+++ b/src/eunit_progress.erl
@@ -347,7 +347,7 @@ format_assertion_failure(assertion_failed, Props, I) ->
              indent(I, "  expected: ~p~n", [proplists:get_value(expected, Props)]),
              indent(I, "       got: ~p", [proplists:get_value(actual, Props)])];
         true ->
-            [indent(I, "Failure/Error: unknown assert: ~s", [Props])]
+            [indent(I, "Failure/Error: unknown assert: ~p", [Props])]
     end;
 
 format_assertion_failure(assertMatch_failed, Props, I) ->


### PR DESCRIPTION
The hamcrest assert library (https://github.com/hyperthunk/hamcrest-erlang) produces assert failures with the same name, as the eunit does, although property names differ. This change detects the assertion by examining property names and also adds a fallback case for printing assertions.
