### PR TITLE
Using cyan to print slowest tests time

### DIFF
--- a/src/eunit_progress.erl
+++ b/src/eunit_progress.erl
@@ -277,7 +277,7 @@ print_timing_fun(#state{status=Status}=State) ->
             TestId = format_test_identifier(TestData),
             io:nl(),
             io:fwrite("  ~s~n", [TestId]),
-            print_colored(["    "|format_time(abs(Time))], ?RED, State)
+            print_colored(["    "|format_time(abs(Time))], ?CYAN, State)
     end.
 
 %%------------------------------------------


### PR DESCRIPTION
Using cyan when printing slowest tests time since red is confusing and reminds failures.
