### PR TITLE
Use undeprecated functions for OTP-21

### DIFF
--- a/src/eunit_progress.erl
+++ b/src/eunit_progress.erl
@@ -463,5 +463,5 @@ indent(I, Fmt, Args) ->
     io_lib:format("~" ++ integer_to_list(I) ++ "s" ++ Fmt, [" "|Args]).
 
 extract_exception_pattern(Str) ->
-    ["{", Class, Term|_] = string:tokens(Str, ", "),
+    ["{", Class, Term|_] = re:split(Str, "[, ]{1,2}", [unicode,{return,list}]),
     {Class, Term}.


### PR DESCRIPTION
Using re:split with the clever pattern prevents having to do
compile-time switching of string: functions, since string:tokens gets
deprecated in OTP-21 and this will produce warnings everywhere.

The unicode flag also allows versions prior to OTP-20 to have unicode
safety in case that would be a thing on error traces.