### PR TITLE
Handle ?assertNot failure

### DIFF
--- a/src/eunit_progress.erl
+++ b/src/eunit_progress.erl
@@ -350,11 +350,16 @@ format_assertion_failure(Type, Props, I) when Type =:= assertion_failed
     HasHamcrestProps = ([expected, actual, matcher] -- Keys) =:= [],
     if
         HasEUnitProps ->
-            [indent(I, "Failure/Error: ?assert(~ts)~n", [proplists:get_value(expression, Props)]),
-             indent(I, "  expected: true~n", []),
+            Expected = proplists:get_value(expected, Props),
+            AssertMacro = case Expected of
+                              true -> assert;
+                              false -> assertNot
+                          end,
+            [indent(I, "Failure/Error: ?~p(~ts)~n", [AssertMacro, proplists:get_value(expression, Props)]),
+             indent(I, "  expected: ~p~n", [Expected]),
              case proplists:get_value(value, Props) of
-                 false ->
-                     indent(I, "       got: false", []);
+                 Bool when is_boolean(Bool) ->
+                     indent(I, "       got: ~p", [Bool]);
                  {not_a_boolean, V} ->
                      indent(I, "       got: ~p", [V])
              end];

--- a/test/eunit_progress_tests.erl
+++ b/test/eunit_progress_tests.erl
@@ -23,11 +23,12 @@ basic_test() ->
         Tests = [
             fun () -> ?assert(true) end,
             fun () -> ?assert(false) end,
+            fun () -> ?assertNot(true) end,
             fun () -> error(some) end
         ],
         eunit:test(Tests, [no_tty, {report, {eunit_progress, [colored, profile]}}])
     end),
-    ?assertMatch(match, re:run(Output, "^.*\\..*F.*F.*\nFailures.*", [{capture, none}])).
+    ?assertMatch(match, re:run(Output, "^.*\\..*F.*F.*F.*\nFailures.*", [{capture, none}])).
 
 
 %%


### PR DESCRIPTION
Before it resulted in
```
{{case_clause,true},
 [{eunit_progress,format_assertion_failure,3,
                  [{file,"/Users/ext.pgomori/git/eunit_formatters/src/eunit_progress.erl"},
                   {line,355}]},
...
```